### PR TITLE
feat(scaleway-certmanager-webhook): add support for extra env variables

### DIFF
--- a/charts/scaleway-certmanager-webhook/templates/deployment.yaml
+++ b/charts/scaleway-certmanager-webhook/templates/deployment.yaml
@@ -34,6 +34,9 @@ spec:
           env:
             - name: GROUP_NAME
               value: {{ .Values.groupName | quote }}
+          {{- with .Values.extraEnv }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{ if and .Values.secret.accessKey .Values.secret.secretKey }}
           envFrom:
           - secretRef:

--- a/charts/scaleway-certmanager-webhook/values.yaml
+++ b/charts/scaleway-certmanager-webhook/values.yaml
@@ -51,6 +51,11 @@ image:
   imagePullSecrets: []
   tag: ""
 
+## @param extraEnv Additional environment variables to pass to the webhook deployment
+extraEnv: []
+# - name: SOME_VAR
+#   value: 'some value'
+
 ## @param service.type Service type exposing the webhook
 ## @param service.port Service port exposing the webhook
 service:


### PR DESCRIPTION
Hello,

This PR adds the parameter `extraEnv` to the Helm chart `scaleway-certmanager-webhook`. This parameter allows to pass additional environment variables to the certmanager-webhook binary.
It can be useful if you want to configure an HTTP proxy for example.