### PR TITLE
fix(cert-manager-webhook): use correct var ref

### DIFF
--- a/charts/scaleway-certmanager-webhook/Chart.yaml
+++ b/charts/scaleway-certmanager-webhook/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "v0.1.0"
 description: Cert-Manager webhook for Scaleway
 name: scaleway-certmanager-webhook
-version: 0.2.0
+version: 0.2.1

--- a/charts/scaleway-certmanager-webhook/README.md
+++ b/charts/scaleway-certmanager-webhook/README.md
@@ -43,6 +43,7 @@ Common parameters.
 | `image.pullPolicy`       | Image pull policy                                 | `IfNotPresent`                           |
 | `image.imagePullSecrets` | Image pull secrets                                | `[]`                                     |
 | `image.tag`              | Tag for the webhook image, defaults to AppVersion | `""`                                     |
+| `extraEnv`               | Additional environment variables for deployment   | `[]`                                     |
 | `service.type`           | Service type exposing the webhook                 | `ClusterIP`                              |
 | `service.port`           | Service port exposing the webhook                 | `443`                                    |
 | `resources`              | Resources definition                              | `{}`                                     |

--- a/charts/scaleway-certmanager-webhook/templates/deployment.yaml
+++ b/charts/scaleway-certmanager-webhook/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         app: {{ include "scaleway-webhook.name" . }}
         release: {{ .Release.Name }}
         {{- with .Values.podLabels }}
-        {{ toYaml .Values.podLabels | indent 8 }}
+        {{ toYaml . | indent 8 }}
         {{- end }}
     spec:
       serviceAccountName: {{ include "scaleway-webhook.fullname" . }}


### PR DESCRIPTION
Got an issue with the chart when using the podLabels.

<code>Helm install failed for release cert-manager/cert-manager-webhook with chart scaleway-certmanager-webhook@0.2.0: template: scaleway-certmanager-webhook/templates/deployment.yaml:22:25: executing "scaleway-certmanager-webhook/templates/deployment.yaml" at <.Values.podLabels>: nil pointer evaluating interface {}.podLabels</code>