### PR TITLE
feat(cert-manager-webhook): add listenport variable

### DIFF
--- a/charts/scaleway-certmanager-webhook/Chart.yaml
+++ b/charts/scaleway-certmanager-webhook/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "v0.1.0"
 description: Cert-Manager webhook for Scaleway
 name: scaleway-certmanager-webhook
-version: 0.3.0
+version: 0.4.0

--- a/charts/scaleway-certmanager-webhook/README.md
+++ b/charts/scaleway-certmanager-webhook/README.md
@@ -46,6 +46,7 @@ Common parameters.
 | `extraEnv`               | Additional environment variables to pass to the webhook deployment | `[]`                                     |
 | `service.type`           | Service type exposing the webhook                                  | `ClusterIP`                              |
 | `service.port`           | Service port exposing the webhook                                  | `443`                                    |
+| `listenPort`             | Port the webhook listens on                                        | `443`                                    |
 | `resources`              | Resources definition                                               | `{}`                                     |
 | `podLabels`              | Pod labels                                                         | `{}`                                     |
 | `nodeSelector`           | Node selector                                                      | `{}`                                     |

--- a/charts/scaleway-certmanager-webhook/templates/deployment.yaml
+++ b/charts/scaleway-certmanager-webhook/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           args:
             - --tls-cert-file=/tls/tls.crt
             - --tls-private-key-file=/tls/tls.key
-            - --secure-port={{ .Values.listenPort | default 443 }}
+            - --secure-port={{ .Values.listenPort }}
           env:
             - name: GROUP_NAME
               value: {{ .Values.groupName | quote }}
@@ -48,7 +48,7 @@ spec:
           {{- end }}
           ports:
             - name: https
-              containerPort: {{ .Values.listenPort | default 443 }}
+              containerPort: {{ .Values.listenPort }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/scaleway-certmanager-webhook/templates/deployment.yaml
+++ b/charts/scaleway-certmanager-webhook/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
           args:
             - --tls-cert-file=/tls/tls.crt
             - --tls-private-key-file=/tls/tls.key
+            - --secure-port={{ .Values.listenPort | default 443 }}
           env:
             - name: GROUP_NAME
               value: {{ .Values.groupName | quote }}
@@ -47,7 +48,7 @@ spec:
           {{- end }}
           ports:
             - name: https
-              containerPort: 443
+              containerPort: {{ .Values.listenPort | default 443 }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/scaleway-certmanager-webhook/values.yaml
+++ b/charts/scaleway-certmanager-webhook/values.yaml
@@ -56,6 +56,9 @@ extraEnv: []
 # - name: SOME_VAR
 #   value: 'some value'
 
+## @param listenPort Port the webhook listens on
+listenPort: 443
+
 ## @param service.type Service type exposing the webhook
 ## @param service.port Service port exposing the webhook
 service:


### PR DESCRIPTION
Add the possibility to have cert-manager-webhook bind to a non-privileged port.

This enables running the webhook in a restricted namespace (`pod-security.kubernetes.io/enforce: restricted`) with the following extra settings:

```
listenPort: 8443

podSecurityContext:
  fsGroup: 1001
  runAsUser: 1001
  runAsGroup: 1001

securityContext:
  allowPrivilegeEscalation: false
  capabilities:
    drop:
    - ALL
  readOnlyRootFilesystem: true
  runAsNonRoot: true
  seccompProfile:
    type: RuntimeDefault
```