### PR TITLE
fix(scaleway-cilium-hubble): disable secrets namespace creation by default

### DIFF
--- a/charts/scaleway-cilium-hubble/Chart.yaml
+++ b/charts/scaleway-cilium-hubble/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: scaleway-cilium-hubble
 description: A Helm chart for adding Hubble to Cilium managed by Scaleway
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "v1.17.3"
 sources:
   - https://github.com/scaleway/helm-charts/scaleway-cilium-hubble

--- a/charts/scaleway-cilium-hubble/values.yaml
+++ b/charts/scaleway-cilium-hubble/values.yaml
@@ -58,3 +58,18 @@ cilium:
     enabled: false
   envoy:
     enabled: false
+
+  # Disable namespace creation to avoid conflicts with Scaleway-managed resources
+  tls:
+    secretsNamespace:
+      create: false
+      name: ""
+  envoyConfig:
+    secretsNamespace:
+      create: false
+  ingressController:
+    secretsNamespace:
+      create: false
+  gatewayAPI:
+    secretsNamespace:
+      create: false


### PR DESCRIPTION
## Summary
Disables creation of the cilium-secrets namespace and related resources to avoid conflicts with Scaleway-managed Cilium installations.

## Problem
When deploying the scaleway-cilium-hubble chart on Scaleway Kapsule clusters, Helm encounters errors because:
- The `cilium-secrets` namespace is already created by Scaleway's Cilium installation
- Associated Roles and RoleBindings exist without Helm ownership metadata
- Helm refuses to adopt these resources without proper annotations/labels

## Solution
Set default values to prevent namespace creation:
- `cilium.tls.secretsNamespace.create: false` and `cilium.tls.secretsNamespace.name: ""`
- `cilium.envoyConfig.secretsNamespace.create: false`
- `cilium.ingressController.secretsNamespace.create: false`
- `cilium.gatewayAPI.secretsNamespace.create: false`

This allows the chart to install without errors on Scaleway-managed clusters while maintaining compatibility with the existing Cilium installation.

## Testing
Tested on Scaleway Kapsule clusters running Kubernetes 1.33.4 and 1.34.2 with Cilium CNI.