### PR TITLE
chore(scaleway-cilium-hubble): bump cilium to 1.18.12

### DIFF
--- a/charts/scaleway-cilium-hubble/Chart.lock
+++ b/charts/scaleway-cilium-hubble/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cilium
   repository: https://helm.cilium.io/
-  version: 1.17.3
-digest: sha256:863c9ed7998f77fae0622aec930452728ff1cb98120641282a688b04eb23bf13
-generated: "2025-04-24T15:17:46.245780627+02:00"
+  version: 1.18.12
+digest: sha256:58b25a9a46020c58ab3241781197a2d1415a58f3f94b4c6f85ae03a6b6d841bb
+generated: "2026-07-17T11:44:51.298459+02:00"

--- a/charts/scaleway-cilium-hubble/Chart.yaml
+++ b/charts/scaleway-cilium-hubble/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scaleway-cilium-hubble
 description: A Helm chart for adding Hubble to Cilium managed by Scaleway
 type: application
-version: 0.1.3
-appVersion: "v1.17.3"
+version: 0.2.0
+appVersion: "v1.18.12"
 sources:
   - https://github.com/scaleway/helm-charts/scaleway-cilium-hubble
 home: https://github.com/scaleway/helm-charts/scaleway-cilium-hubble
@@ -14,5 +14,5 @@ keywords:
 kubeVersion: ">= 1.31.0"
 dependencies:
   - name: cilium
-    version: 1.17.3
+    version: 1.18.12
     repository: https://helm.cilium.io/


### PR DESCRIPTION
## What
Bump the `cilium` dependency and `appVersion` of `scaleway-cilium-hubble` from `v1.17.3` to `v1.18.12`, and release chart version `0.2.0`.

## Why
The chart currently pulls Hubble relay/UI from the Cilium **1.17.3** chart, while Kapsule clusters can run Cilium **1.18**. This minor-version skew between the Hubble relay and the Cilium agent leads to unreliable flow delivery to `hubble-relay`/`cilium connectivity test`. Aligning the dependency to the 1.18 line resolves it.

## Changes
- `Chart.yaml`: `dependencies.cilium.version` `1.17.3` → `1.18.12`; `appVersion` `v1.17.3` → `v1.18.12`; chart `version` `0.1.3` → `0.2.0`
- `Chart.lock`: regenerated

## Validation
- `helm dependency update` succeeds
- `helm lint` passes (only the pre-existing "icon is recommended" info)
- `helm template` renders cleanly (13 manifests) with the chart's default values — no values-schema regressions from the 1.17 → 1.18 jump

> Companion to the 1.19 bump (chart `0.3.0`, #52); both released chart versions remain installable via `--version` for clusters on their respective Cilium line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

