### PR TITLE
feat: add scaleway-secrets-store-csi chart

### DIFF
--- a/charts/scaleway-secrets-store-csi/.helmignore
+++ b/charts/scaleway-secrets-store-csi/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/scaleway-secrets-store-csi/Chart.yaml
+++ b/charts/scaleway-secrets-store-csi/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: scaleway-secrets-store-csi
+description: A Helm chart to install Scaleway Secret Manager Provider for Secret Store CSI Driver.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+sources:
+  - https://github.com/scaleway/scaleway-secrets-store-csi
+home: https://github.com/scaleway/scaleway-secrets-store-csi
+keywords:
+  - scaleway
+  - secrets-store
+  - csi

--- a/charts/scaleway-secrets-store-csi/README.md
+++ b/charts/scaleway-secrets-store-csi/README.md
@@ -1,0 +1,4 @@
+# Scaleway Secrets Store CSI Helm chart
+
+Please refer to the [scaleway-secrets-store-csi repository](https://github.com/scaleway/scaleway-secrets-store-csi)
+for installation and usage instructions.

--- a/charts/scaleway-secrets-store-csi/templates/_helpers.tpl
+++ b/charts/scaleway-secrets-store-csi/templates/_helpers.tpl
@@ -1,0 +1,35 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "secrets-store-csi-driver-provider-scw.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "secrets-store-csi-driver-provider-scw.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "secrets-store-csi-driver-provider-scw.labels" -}}
+helm.sh/chart: {{ include "secrets-store-csi-driver-provider-scw.chart" . }}
+{{ include "secrets-store-csi-driver-provider-scw.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/part-of: secrets-store-csi-driver
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "secrets-store-csi-driver-provider-scw.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "secrets-store-csi-driver-provider-scw.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: provider
+{{- end }}

--- a/charts/scaleway-secrets-store-csi/templates/clusterrole.yaml
+++ b/charts/scaleway-secrets-store-csi/templates/clusterrole.yaml
@@ -1,0 +1,6 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "secrets-store-csi-driver-provider-scw.name" . }}
+  labels:
+    {{- include "secrets-store-csi-driver-provider-scw.labels" . | nindent 4 }}

--- a/charts/scaleway-secrets-store-csi/templates/clusterrolebinding.yaml
+++ b/charts/scaleway-secrets-store-csi/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "secrets-store-csi-driver-provider-scw.name" . }}
+  labels:
+    {{- include "secrets-store-csi-driver-provider-scw.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "secrets-store-csi-driver-provider-scw.name" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "secrets-store-csi-driver-provider-scw.name" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/scaleway-secrets-store-csi/templates/daemonset.yaml
+++ b/charts/scaleway-secrets-store-csi/templates/daemonset.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "secrets-store-csi-driver-provider-scw.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "secrets-store-csi-driver-provider-scw.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "secrets-store-csi-driver-provider-scw.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "secrets-store-csi-driver-provider-scw.labels" . | nindent 8 }}
+      {{- with .Values.pod.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "secrets-store-csi-driver-provider-scw.name" . }}
+      {{- if .Values.pod.priorityClassName }}
+      priorityClassName: {{ .Values.pod.priorityClassName }}
+      {{- end }}
+      containers:
+        - name: provider
+          image: "{{ .Values.pod.image.repository }}:{{ .Values.pod.image.tag }}"
+          imagePullPolicy: {{ .Values.pod.image.pullPolicy }}
+          args:
+            - -debug={{ .Values.provider.debug }}
+          env:
+            {{- if .Values.provider.scaleway.apiURL }}
+            - name: SCW_API_URL
+              value: {{ .Values.provider.scaleway.apiURL }}
+            {{- end }}
+            {{- if .Values.provider.scaleway.insecure }}
+            - name: SCW_INSECURE
+              value: {{ .Values.provider.scaleway.insecure | quote }}
+            {{- end }}
+            {{- if .Values.provider.scaleway.defaultOrganizationID }}
+            - name: SCW_DEFAULT_ORGANIZATION_ID
+              value: {{ .Values.provider.scaleway.defaultOrganizationID }}
+            {{- end }}
+            {{- if .Values.provider.scaleway.defaultProjectID }}
+            - name: SCW_DEFAULT_PROJECT_ID
+              value: {{ .Values.provider.scaleway.defaultProjectID }}
+            {{- end }}
+            {{- if .Values.provider.scaleway.defaultRegion }}
+            - name: SCW_DEFAULT_REGION
+              value: {{ .Values.provider.scaleway.defaultRegion }}
+            {{- end }}
+            {{- if .Values.provider.scaleway.accessKey.secretKeyRef.name }}
+            - name: SCW_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.provider.scaleway.accessKey.secretKeyRef.name }}
+                  key: {{ .Values.provider.scaleway.accessKey.secretKeyRef.key | default "accessKey" }}
+            {{- end }}
+            {{- if .Values.provider.scaleway.secretKey.secretKeyRef.name }}
+            - name: SCW_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.provider.scaleway.secretKey.secretKeyRef.name }}
+                  key: {{ .Values.provider.scaleway.secretKey.secretKeyRef.key | default "secretKey" }}
+            {{- end }}
+          ports:
+            - name: health
+              containerPort: 8080
+          volumeMounts:
+            - name: provider-socket
+              mountPath: /etc/kubernetes/secrets-store-csi-providers
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: health
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: health
+          resources:
+            {{- toYaml .Values.pod.resources | nindent 12 }}
+      volumes:
+        - name: provider-socket
+          hostPath:
+            path: /etc/kubernetes/secrets-store-csi-providers
+      {{- with .Values.pod.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.pod.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.pod.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/scaleway-secrets-store-csi/templates/serviceaccount.yaml
+++ b/charts/scaleway-secrets-store-csi/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "secrets-store-csi-driver-provider-scw.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "secrets-store-csi-driver-provider-scw.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/charts/scaleway-secrets-store-csi/values.yaml
+++ b/charts/scaleway-secrets-store-csi/values.yaml
@@ -1,0 +1,40 @@
+nameOverride: ""
+
+serviceAccount:
+  annotations: {}
+
+pod:
+  annotations: {}
+  priorityClassName: ""
+  image:
+    repository: scaleway/scaleway-secrets-store-csi
+    tag: "0.1.0"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 50m
+      memory: 100Mi
+    limits:
+      cpu: 50m
+      memory: 100Mi
+  nodeSelector:
+    kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+  affinity: {}
+  tolerations: []
+
+provider:
+  debug: false
+  scaleway:
+    apiURL: "https://api.scaleway.com"
+    insecure: false
+    defaultOrganizationID:
+    defaultProjectID:
+    accessKey:
+      secretKeyRef:
+        name:
+        key:
+    secretKey:
+      secretKeyRef:
+        name:
+        key:


### PR DESCRIPTION
This PR adds a new chart `scaleway-secrets-store-csi`. This chart deploys a [Scaleway Secret Manager](https://www.scaleway.com/fr/secret-manager/) provider for [Secrets Store CSI Driver](https://secrets-store-csi-driver.sigs.k8s.io/), allowing users to fetch secrets stored in Scaleway Secret Manager and use the Secrets Store CSI driver interface to mount them into Kubernetes pods.

The provider code is available here: https://github.com/scaleway/scaleway-secrets-store-csi.