### PR TITLE
feat(scaleway-secrets-store-csi): use appVersion as default tag

### DIFF
--- a/charts/scaleway-secrets-store-csi/Chart.yaml
+++ b/charts/scaleway-secrets-store-csi/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: scaleway-secrets-store-csi
 description: A Helm chart to install Scaleway Secret Manager Provider for Secret Store CSI Driver.
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.1
+appVersion: "v0.1.1"
 sources:
   - https://github.com/scaleway/scaleway-secrets-store-csi
 home: https://github.com/scaleway/scaleway-secrets-store-csi

--- a/charts/scaleway-secrets-store-csi/templates/daemonset.yaml
+++ b/charts/scaleway-secrets-store-csi/templates/daemonset.yaml
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       containers:
         - name: provider
-          image: "{{ .Values.pod.image.repository }}:{{ .Values.pod.image.tag }}"
+          image: "{{ .Values.pod.image.repository }}:{{ .Values.pod.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.pod.image.pullPolicy }}
           args:
             - -debug={{ .Values.provider.debug }}

--- a/charts/scaleway-secrets-store-csi/values.yaml
+++ b/charts/scaleway-secrets-store-csi/values.yaml
@@ -8,7 +8,8 @@ pod:
   priorityClassName: ""
   image:
     repository: scaleway/scaleway-secrets-store-csi
-    tag: "0.1.0"
+    # Overrides the image tag whose default is the chart appVersion.
+    tag:
     pullPolicy: IfNotPresent
   resources:
     requests:
@@ -19,7 +20,6 @@ pod:
       memory: 100Mi
   nodeSelector:
     kubernetes.io/os: linux
-    kubernetes.io/arch: amd64
   affinity: {}
   tolerations: []
 
@@ -33,8 +33,8 @@ provider:
     accessKey:
       secretKeyRef:
         name:
-        key:
+        key: accessKey
     secretKey:
       secretKeyRef:
         name:
-        key:
+        key: secretKey


### PR DESCRIPTION
- Use appVersion as default tag 
- Remove node selector `amd64`
- Set default keys for `accessKey` and `secretKey`